### PR TITLE
Add sys_rename syscall (Linux)

### DIFF
--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -21,6 +21,7 @@ This document describes all system calls implemented in the KoraLayer compatibil
 | [`sys_closedir`](#sys_closedir) | 13 | Close a directory |
 | [`sys_symlink`](#sys_symlink) | 14 | Create a symbolic link |
 | [`sys_readlink`](#sys_readlink) | 15 | Read the target of a symbolic link |
+| [`sys_rename`](#sys_rename) | 20 | Rename a file or directory |
 
 ## Common Constants
 
@@ -664,4 +665,41 @@ int main() {
 **Implementation Notes:**
 - Linux: Uses glibc `readlink()` function, ensures null-termination
 - macOS: Not yet implemented
-- Windows: Not yet implemented 
+- Windows: Not yet implemented
+
+### sys_rename
+
+**System Call Number:** 20
+
+**Prototype:**
+```c
+int sys_rename(const char *oldpath, const char *newpath);
+```
+
+**Description:**
+Renames a file or directory from `oldpath` to `newpath`.
+
+**Parameters:**
+- `oldpath`: Existing path of the file or directory
+- `newpath`: New desired path
+
+**Return Value:**
+- `0` on success
+- Negative error code on failure
+
+**Example:**
+```c
+#include <kora/syscalls.h>
+
+int main() {
+    if (sys_rename("/tmp/oldname.txt", "/tmp/newname.txt") == 0) {
+        // rename successful
+    }
+    return 0;
+}
+```
+
+**Implementation Notes:**
+- Linux: Uses glibc `rename()` function
+- macOS: Not yet implemented
+- Windows: Not yet implemented

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -43,6 +43,7 @@
     int linux_sys_symlink(const char *target, const char *linkpath);
     int linux_sys_readlink(const char *path, char *buf, size_t size);
     int linux_sys_unlink(const char *path);
+    int linux_sys_rename(const char *oldpath, const char *newpath);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
@@ -63,6 +64,7 @@
     int macos_sys_symlink(const char *target, const char *linkpath);
     int macos_sys_readlink(const char *path, char *buf, size_t size);
     int macos_sys_unlink(const char *path);
+    int macos_sys_rename(const char *oldpath, const char *newpath);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
@@ -83,6 +85,7 @@
     int windows_sys_symlink(const char *target, const char *linkpath);
     int windows_sys_readlink(const char *path, char *buf, size_t size);
     int windows_sys_unlink(const char *path);
+    int windows_sys_rename(const char *oldpath, const char *newpath);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -35,6 +35,7 @@ extern "C" {
 #define SYS_GET_FILE_INFO 17 /* Get file information by path */
 #define SYS_GET_FD_INFO   18 /* Get file information by descriptor */
 #define SYS_EXISTS     19  /* Check if a path exists */
+#define SYS_RENAME     20  /* Rename a file or directory */
 
 /**
  * File open flags
@@ -283,6 +284,14 @@ int sys_exists(const char *path, uint8_t *type);
  * @return 0 on success, negative error code on failure
  */
 int sys_unlink(const char *path);
+
+/**
+ * Rename a file or directory
+ * @param oldpath Existing path
+ * @param newpath New path name
+ * @return 0 on success, negative error code on failure
+ */
+int sys_rename(const char *oldpath, const char *newpath);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -454,5 +454,21 @@ int linux_sys_unlink(const char *path)
     }
     
     return 0;
-} 
+}
+
+/**
+ * Rename a file or directory
+ */
+int linux_sys_rename(const char *oldpath, const char *newpath)
+{
+    if (!oldpath || !newpath) {
+        return -EINVAL;
+    }
+
+    if (rename(oldpath, newpath) != 0) {
+        return -errno;
+    }
+
+    return 0;
+}
 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -195,3 +195,13 @@ int sys_unlink(const char *path) {
     return windows_sys_unlink(path);
 #endif
 }
+
+int sys_rename(const char *oldpath, const char *newpath) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_rename(oldpath, newpath);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_rename(oldpath, newpath);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_rename(oldpath, newpath);
+#endif
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_FILES
     test_io.c
     test_putc.c
     test_unlink.c
+    test_rename.c
 )
 
 # Platform specific test configurations

--- a/tests/test_rename.c
+++ b/tests/test_rename.c
@@ -1,0 +1,74 @@
+/**
+ * Test for rename syscall using CMocka
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define SRC_FILE "/tmp/kora_test_rename_src.txt"
+#define DST_FILE "/tmp/kora_test_rename_dst.txt"
+
+struct test_data {
+    int fd;
+};
+
+static int setup(void **state) {
+    struct test_data *data = malloc(sizeof(struct test_data));
+    if (!data) {
+        return -1;
+    }
+    data->fd = -1;
+    sys_unlink(SRC_FILE);
+    sys_unlink(DST_FILE);
+    *state = data;
+    return 0;
+}
+
+static int teardown(void **state) {
+    struct test_data *data = *state;
+    if (data->fd >= 0) {
+        sys_close(data->fd);
+    }
+    sys_unlink(SRC_FILE);
+    sys_unlink(DST_FILE);
+    free(data);
+    return 0;
+}
+
+static void test_rename_basic(void **state) {
+    struct test_data *data = *state;
+    int ret;
+    uint8_t type;
+
+    data->fd = sys_open(SRC_FILE, KORA_O_WRONLY | KORA_O_CREAT | KORA_O_TRUNC);
+    assert_true(data->fd >= 0);
+
+    ret = sys_write(data->fd, "rename", 6);
+    assert_int_equal(ret, 6);
+
+    ret = sys_close(data->fd);
+    assert_int_equal(ret, KORA_SUCCESS);
+    data->fd = -1;
+
+    ret = sys_rename(SRC_FILE, DST_FILE);
+    assert_int_equal(ret, 0);
+
+    ret = sys_exists(DST_FILE, &type);
+    assert_true(ret > 0);
+    assert_int_equal(type, KORA_FILE_TYPE_REGULAR);
+
+    ret = sys_exists(SRC_FILE, &type);
+    assert_int_equal(ret, 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_rename_basic, setup, teardown),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- introduce `SYS_RENAME` constant and `sys_rename` API
- implement `linux_sys_rename`
- dispatch new syscall in platform wrapper
- document syscall in `docs/syscalls.md`
- add CMocka test for rename

## Testing
- `cmake ..` *(fails: Could NOT find CMocka)*

------
https://chatgpt.com/codex/tasks/task_e_686a73bf748c832a92d0d9a0125b2223