### PR TITLE
Add linear heap syscalls

### DIFF
--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -22,6 +22,8 @@ This document describes all system calls implemented in the KoraLayer compatibil
 | [`sys_symlink`](#sys_symlink) | 14 | Create a symbolic link |
 | [`sys_readlink`](#sys_readlink) | 15 | Read the target of a symbolic link |
 | [`sys_rename`](#sys_rename) | 20 | Rename a file or directory |
+| [`sys_brk`](#sys_brk) | 21 | Set program break |
+| [`sys_sbrk`](#sys_sbrk) | 22 | Adjust program break |
 
 ## Common Constants
 
@@ -702,4 +704,68 @@ int main() {
 **Implementation Notes:**
 - Linux: Uses glibc `rename()` function
 - macOS: Not yet implemented
+- Windows: Not yet implemented
+
+### sys_brk
+
+**System Call Number:** 21
+
+**Prototype:**
+```c
+void *sys_brk(void *new_end);
+```
+
+**Description:**
+Moves the program break to `new_end`.
+
+**Parameters:**
+- `new_end`: New end address for the data segment
+
+**Return Value:**
+- New program break address on success
+- `(void*)-1` on failure
+
+**Example:**
+```c
+void *cur = sys_brk(some_addr);
+if (cur == (void*)-1) {
+    // error
+}
+```
+
+**Implementation Notes:**
+- Linux: Uses glibc `brk()` and `sbrk(0)`
+- macOS: Same as Linux
+- Windows: Not yet implemented
+
+### sys_sbrk
+
+**System Call Number:** 22
+
+**Prototype:**
+```c
+void *sys_sbrk(ptrdiff_t delta);
+```
+
+**Description:**
+Adjusts the program break by `delta` bytes.
+
+**Parameters:**
+- `delta`: Number of bytes to add to the break (can be negative)
+
+**Return Value:**
+- Previous program break address on success
+- `(void*)-1` on failure
+
+**Example:**
+```c
+void *old = sys_sbrk(4096);
+if (old != (void*)-1) {
+    // use memory starting at old
+}
+```
+
+**Implementation Notes:**
+- Linux: Uses glibc `sbrk()`
+- macOS: Same as Linux
 - Windows: Not yet implemented

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -44,6 +44,8 @@
     int linux_sys_readlink(const char *path, char *buf, size_t size);
     int linux_sys_unlink(const char *path);
     int linux_sys_rename(const char *oldpath, const char *newpath);
+    void *linux_sys_brk(void *new_end);
+    void *linux_sys_sbrk(ptrdiff_t delta);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
@@ -65,6 +67,8 @@
     int macos_sys_readlink(const char *path, char *buf, size_t size);
     int macos_sys_unlink(const char *path);
     int macos_sys_rename(const char *oldpath, const char *newpath);
+    void *macos_sys_brk(void *new_end);
+    void *macos_sys_sbrk(ptrdiff_t delta);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
@@ -86,6 +90,8 @@
     int windows_sys_readlink(const char *path, char *buf, size_t size);
     int windows_sys_unlink(const char *path);
     int windows_sys_rename(const char *oldpath, const char *newpath);
+    void *windows_sys_brk(void *new_end);
+    void *windows_sys_sbrk(ptrdiff_t delta);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -36,6 +36,8 @@ extern "C" {
 #define SYS_GET_FD_INFO   18 /* Get file information by descriptor */
 #define SYS_EXISTS     19  /* Check if a path exists */
 #define SYS_RENAME     20  /* Rename a file or directory */
+#define SYS_BRK        21  /* Set program break */
+#define SYS_SBRK       22  /* Change program break by delta */
 
 /**
  * File open flags
@@ -292,6 +294,20 @@ int sys_unlink(const char *path);
  * @return 0 on success, negative error code on failure
  */
 int sys_rename(const char *oldpath, const char *newpath);
+
+/**
+ * Set the program break to a specific address
+ * @param new_end New end of the data segment
+ * @return New program break on success, (void*)-1 on failure
+ */
+void *sys_brk(void *new_end);
+
+/**
+ * Adjust the program break by a delta
+ * @param delta Number of bytes to add to the break (can be negative)
+ * @return Previous program break on success, (void*)-1 on failure
+ */
+void *sys_sbrk(ptrdiff_t delta);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -472,3 +472,16 @@ int linux_sys_rename(const char *oldpath, const char *newpath)
     return 0;
 }
 
+void *linux_sys_brk(void *new_end)
+{
+    if (brk(new_end) != 0) {
+        return (void *)-1;
+    }
+    return sbrk(0);
+}
+
+void *linux_sys_sbrk(ptrdiff_t delta)
+{
+    return sbrk(delta);
+}
+

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -463,4 +463,17 @@ int macos_sys_unlink(const char *path)
     return 0;
 }
 
+void *macos_sys_brk(void *new_end)
+{
+    if (brk(new_end) != 0) {
+        return (void *)-1;
+    }
+    return sbrk(0);
+}
+
+void *macos_sys_sbrk(ptrdiff_t delta)
+{
+    return sbrk(delta);
+}
+
 #endif // KORA_PLATFORM_MACOS 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -205,3 +205,23 @@ int sys_rename(const char *oldpath, const char *newpath) {
     return windows_sys_rename(oldpath, newpath);
 #endif
 }
+
+void *sys_brk(void *new_end) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_brk(new_end);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_brk(new_end);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_brk(new_end);
+#endif
+}
+
+void *sys_sbrk(ptrdiff_t delta) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_sbrk(delta);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_sbrk(delta);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_sbrk(delta);
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -45,4 +45,16 @@ int windows_sys_ioctl(int fd, unsigned long request, void *arg) {
     /* TODO: Implement Windows version */
     return KORA_ERROR;
 }
+
+void *windows_sys_brk(void *new_end) {
+    (void)new_end;
+    /* TODO: Implement Windows version */
+    return (void *)-1;
+}
+
+void *windows_sys_sbrk(ptrdiff_t delta) {
+    (void)delta;
+    /* TODO: Implement Windows version */
+    return (void *)-1;
+}
 #endif 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_FILES
     test_putc.c
     test_unlink.c
     test_rename.c
+    test_sbrk.c
 )
 
 # Platform specific test configurations

--- a/tests/test_sbrk.c
+++ b/tests/test_sbrk.c
@@ -1,0 +1,37 @@
+/**
+ * Test for brk and sbrk syscalls using CMocka
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+#include <stdint.h>
+
+static void test_sbrk_basic(void **state) {
+    (void)state;
+    void *start = sys_sbrk(0);
+    assert_ptr_not_equal(start, (void *)-1);
+
+    const ptrdiff_t inc = 4096;
+    void *prev = sys_sbrk(inc);
+    assert_ptr_equal(prev, start);
+
+    char *mem = (char *)prev;
+    mem[0] = 'A';
+    mem[inc - 1] = 'Z';
+
+    void *cur = sys_sbrk(0);
+    assert_ptr_equal((char *)cur, (char *)start + inc);
+
+    void *res = sys_brk(start);
+    assert_ptr_equal(res, start);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_sbrk_basic),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- introduce SYS_BRK and SYS_SBRK numbers
- implement sys_brk and sys_sbrk across platforms
- document the new memory management syscalls
- test sbrk/brk behaviour
