### PR TITLE
Add memory management syscalls

### DIFF
--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -22,6 +22,9 @@ This document describes all system calls implemented in the KoraLayer compatibil
 | [`sys_symlink`](#sys_symlink) | 14 | Create a symbolic link |
 | [`sys_readlink`](#sys_readlink) | 15 | Read the target of a symbolic link |
 | [`sys_rename`](#sys_rename) | 20 | Rename a file or directory |
+| [`sys_mmap`](#sys_mmap) | 23 | Map anonymous or file-backed memory |
+| [`sys_munmap`](#sys_munmap) | 24 | Unmap a memory region |
+| [`sys_mprotect`](#sys_mprotect) | 25 | Change memory protection |
 
 ## Common Constants
 
@@ -702,4 +705,99 @@ int main() {
 **Implementation Notes:**
 - Linux: Uses glibc `rename()` function
 - macOS: Not yet implemented
+- Windows: Not yet implemented
+
+### sys_mmap
+
+**System Call Number:** 23
+
+**Prototype:**
+```c
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+```
+
+**Description:**
+Maps anonymous or file-backed memory into the process address space.
+
+**Parameters:**
+- `addr`: Desired address or `NULL` for automatic placement
+- `len`: Length of the mapping in bytes
+- `prot`: Protection flags (e.g. `PROT_READ`, `PROT_WRITE`)
+- `flags`: Mapping flags (e.g. `MAP_PRIVATE`, `MAP_ANONYMOUS`)
+- `fd`: File descriptor if mapping a file, otherwise `-1`
+- `off`: Offset within the file for the mapping
+
+**Return Value:**
+- Pointer to the mapped region on success
+- `(void *)-1` on failure
+
+**Example:**
+```c
+#include <kora/syscalls.h>
+
+int main() {
+    void *mem = sys_mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (mem != (void *)-1) {
+        // Use memory
+        sys_munmap(mem, 4096);
+    }
+    return 0;
+}
+```
+
+**Implementation Notes:**
+- Linux: Uses POSIX `mmap()`
+- macOS: Uses POSIX `mmap()`
+- Windows: Not yet implemented
+
+### sys_munmap
+
+**System Call Number:** 24
+
+**Prototype:**
+```c
+int sys_munmap(void *addr, size_t len);
+```
+
+**Description:**
+Unmaps a region of memory previously mapped with `sys_mmap`.
+
+**Parameters:**
+- `addr`: Address of the mapping
+- `len`: Length of the mapping
+
+**Return Value:**
+- `0` on success
+- `-1` on failure
+
+**Implementation Notes:**
+- Linux: Uses POSIX `munmap()`
+- macOS: Uses POSIX `munmap()`
+- Windows: Not yet implemented
+
+### sys_mprotect
+
+**System Call Number:** 25
+
+**Prototype:**
+```c
+int sys_mprotect(void *addr, size_t len, int prot);
+```
+
+**Description:**
+Changes the memory protection of an existing mapping.
+
+**Parameters:**
+- `addr`: Address of the mapping
+- `len`: Length of the mapping
+- `prot`: New protection flags
+
+**Return Value:**
+- `0` on success
+- `-1` on failure
+
+**Implementation Notes:**
+- Linux: Uses POSIX `mprotect()`
+- macOS: Uses POSIX `mprotect()`
 - Windows: Not yet implemented

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -47,6 +47,9 @@
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
+    void *linux_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int linux_sys_munmap(void *addr, size_t len);
+    int linux_sys_mprotect(void *addr, size_t len, int prot);
 #elif defined(KORA_PLATFORM_MACOS)
     int macos_sys_putc(char c);
     int macos_sys_getc(void);
@@ -68,6 +71,9 @@
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
+    void *macos_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int macos_sys_munmap(void *addr, size_t len);
+    int macos_sys_mprotect(void *addr, size_t len, int prot);
 #elif defined(KORA_PLATFORM_WINDOWS)
     int windows_sys_putc(char c);
     int windows_sys_getc(void);
@@ -89,4 +95,7 @@
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);
-#endif 
+    void *windows_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int windows_sys_munmap(void *addr, size_t len);
+    int windows_sys_mprotect(void *addr, size_t len, int prot);
+#endif

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -36,6 +36,9 @@ extern "C" {
 #define SYS_GET_FD_INFO   18 /* Get file information by descriptor */
 #define SYS_EXISTS     19  /* Check if a path exists */
 #define SYS_RENAME     20  /* Rename a file or directory */
+#define SYS_MMAP       23  /* Map memory region */
+#define SYS_MUNMAP     24  /* Unmap memory region */
+#define SYS_MPROTECT   25  /* Change memory protection */
 
 /**
  * File open flags
@@ -292,6 +295,21 @@ int sys_unlink(const char *path);
  * @return 0 on success, negative error code on failure
  */
 int sys_rename(const char *oldpath, const char *newpath);
+
+/**
+ * Map anonymous or file-backed memory
+ */
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+
+/**
+ * Unmap a region of memory previously mapped with sys_mmap
+ */
+int sys_munmap(void *addr, size_t len);
+
+/**
+ * Change protection on a region of memory
+ */
+int sys_mprotect(void *addr, size_t len, int prot);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -9,6 +9,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/mman.h>
 
 /**
  * Linux implementation of KoraOS system calls
@@ -469,6 +470,31 @@ int linux_sys_rename(const char *oldpath, const char *newpath)
         return -errno;
     }
 
+    return 0;
+}
+
+void *linux_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+{
+    void *result = mmap(addr, len, prot, flags, fd, off);
+    if (result == MAP_FAILED) {
+        return MAP_FAILED;
+    }
+    return result;
+}
+
+int linux_sys_munmap(void *addr, size_t len)
+{
+    if (munmap(addr, len) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int linux_sys_mprotect(void *addr, size_t len, int prot)
+{
+    if (mprotect(addr, len, prot) != 0) {
+        return -1;
+    }
     return 0;
 }
 

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -10,6 +10,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/mman.h>
 
 /**
  * macOS implementation of KoraOS system calls
@@ -463,4 +464,29 @@ int macos_sys_unlink(const char *path)
     return 0;
 }
 
-#endif // KORA_PLATFORM_MACOS 
+void *macos_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+{
+    void *result = mmap(addr, len, prot, flags, fd, off);
+    if (result == MAP_FAILED) {
+        return MAP_FAILED;
+    }
+    return result;
+}
+
+int macos_sys_munmap(void *addr, size_t len)
+{
+    if (munmap(addr, len) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+int macos_sys_mprotect(void *addr, size_t len, int prot)
+{
+    if (mprotect(addr, len, prot) != 0) {
+        return -1;
+    }
+    return 0;
+}
+
+#endif // KORA_PLATFORM_MACOS

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -205,3 +205,33 @@ int sys_rename(const char *oldpath, const char *newpath) {
     return windows_sys_rename(oldpath, newpath);
 #endif
 }
+
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_mmap(addr, len, prot, flags, fd, off);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_mmap(addr, len, prot, flags, fd, off);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_mmap(addr, len, prot, flags, fd, off);
+#endif
+}
+
+int sys_munmap(void *addr, size_t len) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_munmap(addr, len);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_munmap(addr, len);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_munmap(addr, len);
+#endif
+}
+
+int sys_mprotect(void *addr, size_t len, int prot) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_mprotect(addr, len, prot);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_mprotect(addr, len, prot);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_mprotect(addr, len, prot);
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -45,4 +45,23 @@ int windows_sys_ioctl(int fd, unsigned long request, void *arg) {
     /* TODO: Implement Windows version */
     return KORA_ERROR;
 }
-#endif 
+
+void *windows_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
+    /* TODO: Implement Windows version */
+    (void)addr; (void)len; (void)prot; (void)flags; (void)fd; (void)off;
+    return (void *)-1;
+}
+
+int windows_sys_munmap(void *addr, size_t len) {
+    /* TODO: Implement Windows version */
+    (void)addr; (void)len;
+    return -1;
+}
+
+int windows_sys_mprotect(void *addr, size_t len, int prot) {
+    /* TODO: Implement Windows version */
+    (void)addr; (void)len; (void)prot;
+    return -1;
+}
+
+#endif // KORA_PLATFORM_WINDOWS


### PR DESCRIPTION
## Summary
- add mmap/munmap/mprotect system call numbers and prototypes
- implement dispatchers for new syscalls
- implement Linux/macOS support using POSIX mmap APIs
- add placeholder Windows implementations
- document the new syscalls in the reference
- start numbering at 23