### PR TITLE
Add mmap syscalls and tests

### DIFF
--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -24,6 +24,9 @@ This document describes all system calls implemented in the KoraLayer compatibil
 | [`sys_rename`](#sys_rename) | 20 | Rename a file or directory |
 | [`sys_brk`](#sys_brk) | 21 | Set program break |
 | [`sys_sbrk`](#sys_sbrk) | 22 | Adjust program break |
+| [`sys_mmap`](#sys_mmap) | 23 | Map memory pages |
+| [`sys_munmap`](#sys_munmap) | 24 | Unmap memory pages |
+| [`sys_mprotect`](#sys_mprotect) | 25 | Change memory protection |
 
 ## Common Constants
 
@@ -768,4 +771,84 @@ if (old != (void*)-1) {
 **Implementation Notes:**
 - Linux: Uses glibc `sbrk()`
 - macOS: Same as Linux
+- Windows: Not yet implemented
+
+### sys_mmap
+
+**System Call Number:** 23
+
+**Prototype:**
+```c
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+```
+
+**Description:**
+Maps anonymous or file-backed memory into the process address space.
+
+**Parameters:**
+- `addr`: Desired mapping address or `NULL` for automatic placement
+- `len`: Length of the mapping in bytes
+- `prot`: Protection flags (`PROT_READ`, `PROT_WRITE`, etc.)
+- `flags`: Mapping flags (`MAP_PRIVATE`, `MAP_ANONYMOUS`, etc.)
+- `fd`: File descriptor when mapping a file, or `-1` for anonymous mappings
+- `off`: Offset within the file
+
+**Return Value:**
+- Pointer to the mapped region on success
+- `(void*)-1` on failure
+
+**Implementation Notes:**
+- Linux: Thin wrapper around `mmap()`
+- macOS: Thin wrapper around `mmap()`
+- Windows: Not yet implemented
+
+### sys_munmap
+
+**System Call Number:** 24
+
+**Prototype:**
+```c
+int sys_munmap(void *addr, size_t len);
+```
+
+**Description:**
+Unmaps a previously mapped memory region.
+
+**Parameters:**
+- `addr`: Start address of the mapping
+- `len`: Length of the mapping
+
+**Return Value:**
+- `0` on success
+- `-1` on failure
+
+**Implementation Notes:**
+- Linux: Thin wrapper around `munmap()`
+- macOS: Thin wrapper around `munmap()`
+- Windows: Not yet implemented
+
+### sys_mprotect
+
+**System Call Number:** 25
+
+**Prototype:**
+```c
+int sys_mprotect(void *addr, size_t len, int prot);
+```
+
+**Description:**
+Changes the protection flags of pages in an existing mapping.
+
+**Parameters:**
+- `addr`: Start address
+- `len`: Length of region
+- `prot`: New protection flags
+
+**Return Value:**
+- `0` on success
+- `-1` on failure
+
+**Implementation Notes:**
+- Linux: Wraps `mprotect()`
+- macOS: Wraps `mprotect()`
 - Windows: Not yet implemented

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -46,6 +46,9 @@
     int linux_sys_rename(const char *oldpath, const char *newpath);
     void *linux_sys_brk(void *new_end);
     void *linux_sys_sbrk(ptrdiff_t delta);
+    void *linux_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int linux_sys_munmap(void *addr, size_t len);
+    int linux_sys_mprotect(void *addr, size_t len, int prot);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
@@ -69,6 +72,9 @@
     int macos_sys_rename(const char *oldpath, const char *newpath);
     void *macos_sys_brk(void *new_end);
     void *macos_sys_sbrk(ptrdiff_t delta);
+    void *macos_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int macos_sys_munmap(void *addr, size_t len);
+    int macos_sys_mprotect(void *addr, size_t len, int prot);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
@@ -92,6 +98,9 @@
     int windows_sys_rename(const char *oldpath, const char *newpath);
     void *windows_sys_brk(void *new_end);
     void *windows_sys_sbrk(ptrdiff_t delta);
+    void *windows_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+    int windows_sys_munmap(void *addr, size_t len);
+    int windows_sys_mprotect(void *addr, size_t len, int prot);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -38,6 +38,9 @@ extern "C" {
 #define SYS_RENAME     20  /* Rename a file or directory */
 #define SYS_BRK        21  /* Set program break */
 #define SYS_SBRK       22  /* Change program break by delta */
+#define SYS_MMAP       23  /* Map memory pages */
+#define SYS_MUNMAP     24  /* Unmap memory pages */
+#define SYS_MPROTECT   25  /* Change memory protection */
 
 /**
  * File open flags
@@ -308,6 +311,35 @@ void *sys_brk(void *new_end);
  * @return Previous program break on success, (void*)-1 on failure
  */
 void *sys_sbrk(ptrdiff_t delta);
+
+/**
+ * Map anonymous or file-backed memory into the process address space
+ * @param addr Desired address or NULL
+ * @param len Length of the mapping in bytes
+ * @param prot Protection flags (e.g., PROT_READ, PROT_WRITE)
+ * @param flags Mapping flags (e.g., MAP_PRIVATE, MAP_ANONYMOUS)
+ * @param fd File descriptor if mapping a file, or -1 for anonymous
+ * @param off Offset in the file
+ * @return Pointer to mapped region on success, (void*)-1 on failure
+ */
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
+
+/**
+ * Unmap a previously mapped memory region
+ * @param addr Starting address of the mapping
+ * @param len Length of the mapping
+ * @return 0 on success, -1 on failure
+ */
+int sys_munmap(void *addr, size_t len);
+
+/**
+ * Change the protection of a memory region
+ * @param addr Start address
+ * @param len Length of region
+ * @param prot New protection flags
+ * @return 0 on success, -1 on failure
+ */
+int sys_mprotect(void *addr, size_t len, int prot);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -9,6 +9,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/mman.h>
 
 /**
  * Linux implementation of KoraOS system calls
@@ -483,5 +484,24 @@ void *linux_sys_brk(void *new_end)
 void *linux_sys_sbrk(ptrdiff_t delta)
 {
     return sbrk(delta);
+}
+
+void *linux_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+{
+    void *res = mmap(addr, len, prot, flags, fd, off);
+    if (res == MAP_FAILED) {
+        return (void *)-1;
+    }
+    return res;
+}
+
+int linux_sys_munmap(void *addr, size_t len)
+{
+    return munmap(addr, len);
+}
+
+int linux_sys_mprotect(void *addr, size_t len, int prot)
+{
+    return mprotect(addr, len, prot);
 }
 

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -10,6 +10,7 @@
 #include <dirent.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/mman.h>
 
 /**
  * macOS implementation of KoraOS system calls
@@ -474,6 +475,25 @@ void *macos_sys_brk(void *new_end)
 void *macos_sys_sbrk(ptrdiff_t delta)
 {
     return sbrk(delta);
+}
+
+void *macos_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off)
+{
+    void *res = mmap(addr, len, prot, flags, fd, off);
+    if (res == MAP_FAILED) {
+        return (void *)-1;
+    }
+    return res;
+}
+
+int macos_sys_munmap(void *addr, size_t len)
+{
+    return munmap(addr, len);
+}
+
+int macos_sys_mprotect(void *addr, size_t len, int prot)
+{
+    return mprotect(addr, len, prot);
 }
 
 #endif // KORA_PLATFORM_MACOS 

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -225,3 +225,33 @@ void *sys_sbrk(ptrdiff_t delta) {
     return windows_sys_sbrk(delta);
 #endif
 }
+
+void *sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_mmap(addr, len, prot, flags, fd, off);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_mmap(addr, len, prot, flags, fd, off);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_mmap(addr, len, prot, flags, fd, off);
+#endif
+}
+
+int sys_munmap(void *addr, size_t len) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_munmap(addr, len);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_munmap(addr, len);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_munmap(addr, len);
+#endif
+}
+
+int sys_mprotect(void *addr, size_t len, int prot) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_mprotect(addr, len, prot);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_mprotect(addr, len, prot);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_mprotect(addr, len, prot);
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -57,4 +57,22 @@ void *windows_sys_sbrk(ptrdiff_t delta) {
     /* TODO: Implement Windows version */
     return (void *)-1;
 }
-#endif 
+
+void *windows_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
+    (void)addr; (void)len; (void)prot; (void)flags; (void)fd; (void)off;
+    /* TODO: Implement Windows version */
+    return (void *)-1;
+}
+
+int windows_sys_munmap(void *addr, size_t len) {
+    (void)addr; (void)len;
+    /* TODO: Implement Windows version */
+    return -1;
+}
+
+int windows_sys_mprotect(void *addr, size_t len, int prot) {
+    (void)addr; (void)len; (void)prot;
+    /* TODO: Implement Windows version */
+    return -1;
+}
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_FILES
     test_unlink.c
     test_rename.c
     test_sbrk.c
+    test_mmap.c
 )
 
 # Platform specific test configurations

--- a/tests/test_mmap.c
+++ b/tests/test_mmap.c
@@ -1,0 +1,34 @@
+/**
+ * Test mmap, munmap and mprotect syscalls using CMocka
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+#include <sys/mman.h>
+#include <string.h>
+
+static void test_mmap_basic(void **state) {
+    (void)state;
+    size_t len = 4096;
+    char *mem = sys_mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    assert_ptr_not_equal(mem, (void *)-1);
+
+    strcpy(mem, "kora");
+    assert_string_equal(mem, "kora");
+
+    int ret = sys_mprotect(mem, len, PROT_READ);
+    assert_int_equal(ret, 0);
+
+    ret = sys_munmap(mem, len);
+    assert_int_equal(ret, 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_mmap_basic),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- implement mmap, munmap and mprotect system calls for Linux and macOS
- expose new APIs in public headers and dispatch layer
- document new syscalls in docs
- add placeholder Windows implementations
- add cmocka test for memory mapping
