### PR TITLE
Add scheduling syscalls

### DIFF
--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -49,6 +49,10 @@
     void *linux_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
     int linux_sys_munmap(void *addr, size_t len);
     int linux_sys_mprotect(void *addr, size_t len, int prot);
+    int linux_sys_yield(void);
+    pid_t linux_sys_getpid(void);
+    pid_t linux_sys_getppid(void);
+    int linux_sys_setpriority(pid_t pid, int prio);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
@@ -78,6 +82,10 @@
     void *macos_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
     int macos_sys_munmap(void *addr, size_t len);
     int macos_sys_mprotect(void *addr, size_t len, int prot);
+    int macos_sys_yield(void);
+    pid_t macos_sys_getpid(void);
+    pid_t macos_sys_getppid(void);
+    int macos_sys_setpriority(pid_t pid, int prio);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
@@ -107,6 +115,10 @@
     void *windows_sys_mmap(void *addr, size_t len, int prot, int flags, int fd, off_t off);
     int windows_sys_munmap(void *addr, size_t len);
     int windows_sys_mprotect(void *addr, size_t len, int prot);
+    int windows_sys_yield(void);
+    pid_t windows_sys_getpid(void);
+    pid_t windows_sys_getppid(void);
+    int windows_sys_setpriority(pid_t pid, int prio);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -45,6 +45,10 @@ extern "C" {
 #define SYS_SPAWN      26  /* Spawn a new process */
 #define SYS_EXIT       27  /* Terminate the calling task */
 #define SYS_WAIT       28  /* Wait for a child process */
+#define SYS_YIELD      29  /* Yield the processor */
+#define SYS_GETPID     30  /* Get current process ID */
+#define SYS_GETPPID    31  /* Get parent process ID */
+#define SYS_SETPRIORITY 32 /* Set process scheduling priority */
 
 /**
  * File open flags
@@ -371,6 +375,22 @@ void sys_exit(int status) __attribute__((noreturn));
  * @return PID of the exited child or -1 on error
  */
 pid_t sys_wait(pid_t pid, int *status, int options);
+
+/**
+ * Yield the processor to another runnable task.
+ *
+ * @return 0 on success, -1 on failure
+ */
+int sys_yield(void);
+
+/** Get the current process ID */
+pid_t sys_getpid(void);
+
+/** Get the parent process ID */
+pid_t sys_getppid(void);
+
+/** Set scheduling priority for a process */
+int sys_setpriority(pid_t pid, int prio);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -12,6 +12,8 @@
 #include <sys/mman.h>
 #include <spawn.h>
 #include <sys/wait.h>
+#include <sched.h>
+#include <sys/resource.h>
 extern char **environ;
 
 /**
@@ -532,5 +534,25 @@ pid_t linux_sys_wait(pid_t pid, int *status, int options)
         return -1;
     }
     return res;
+}
+
+int linux_sys_yield(void)
+{
+    return sched_yield();
+}
+
+pid_t linux_sys_getpid(void)
+{
+    return getpid();
+}
+
+pid_t linux_sys_getppid(void)
+{
+    return getppid();
+}
+
+int linux_sys_setpriority(pid_t pid, int prio)
+{
+    return setpriority(PRIO_PROCESS, pid, prio);
 }
 

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -13,6 +13,8 @@
 #include <sys/mman.h>
 #include <spawn.h>
 #include <sys/wait.h>
+#include <sched.h>
+#include <sys/resource.h>
 extern char **environ;
 
 /**
@@ -523,6 +525,26 @@ pid_t macos_sys_wait(pid_t pid, int *status, int options)
         return -1;
     }
     return res;
+}
+
+int macos_sys_yield(void)
+{
+    return sched_yield();
+}
+
+pid_t macos_sys_getpid(void)
+{
+    return getpid();
+}
+
+pid_t macos_sys_getppid(void)
+{
+    return getppid();
+}
+
+int macos_sys_setpriority(pid_t pid, int prio)
+{
+    return setpriority(PRIO_PROCESS, pid, prio);
 }
 
 #endif // KORA_PLATFORM_MACOS

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -286,3 +286,43 @@ pid_t sys_wait(pid_t pid, int *status, int options) {
     return windows_sys_wait(pid, status, options);
 #endif
 }
+
+int sys_yield(void) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_yield();
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_yield();
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_yield();
+#endif
+}
+
+pid_t sys_getpid(void) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_getpid();
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_getpid();
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_getpid();
+#endif
+}
+
+pid_t sys_getppid(void) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_getppid();
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_getppid();
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_getppid();
+#endif
+}
+
+int sys_setpriority(pid_t pid, int prio) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_setpriority(pid, prio);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_setpriority(pid, prio);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_setpriority(pid, prio);
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -93,4 +93,25 @@ pid_t windows_sys_wait(pid_t pid, int *status, int options) {
     /* TODO: Implement Windows version */
     return -1;
 }
+
+int windows_sys_yield(void) {
+    /* TODO: Implement Windows version */
+    return -1;
+}
+
+pid_t windows_sys_getpid(void) {
+    /* TODO: Implement Windows version */
+    return -1;
+}
+
+pid_t windows_sys_getppid(void) {
+    /* TODO: Implement Windows version */
+    return -1;
+}
+
+int windows_sys_setpriority(pid_t pid, int prio) {
+    (void)pid; (void)prio;
+    /* TODO: Implement Windows version */
+    return -1;
+}
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_FILES
     test_sbrk.c
     test_mmap.c
     test_spawn.c
+    test_sched.c
 )
 
 # Platform specific test configurations

--- a/tests/test_sched.c
+++ b/tests/test_sched.c
@@ -1,0 +1,34 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+#include <unistd.h>
+
+static void test_getpid_getppid(void **state) {
+    (void)state;
+    assert_int_equal(sys_getpid(), getpid());
+    assert_int_equal(sys_getppid(), getppid());
+}
+
+static void test_yield_call(void **state) {
+    (void)state;
+    int ret = sys_yield();
+    assert_int_equal(ret, 0);
+}
+
+static void test_setpriority_call(void **state) {
+    (void)state;
+    pid_t pid = sys_getpid();
+    int ret = sys_setpriority(pid, 0);
+    assert_int_equal(ret, 0);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_getpid_getppid),
+        cmocka_unit_test(test_yield_call),
+        cmocka_unit_test(test_setpriority_call),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- add scheduling syscall constants and prototypes
- implement sys_yield, sys_getpid, sys_getppid and sys_setpriority for Linux/macOS
- provide stub implementations for Windows
- expose new syscalls through dispatcher
- add cmocka tests for the new process control syscalls
