### PR TITLE
Add timer syscalls for Linux/MacOS

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3,8 +3,7 @@
 This document outlines the remaining work required to flesh out the KoraOS C library on top of the shim provided by KoraLayer.
 
 ## 1. Timers & Clocks
-- Implement `sys_clock_gettime`, `sys_gettimeofday`, `sys_nanosleep`, and the `sleep()` wrapper.
-- Optional: `sys_setitimer` for profilers.
+- Basic timer syscalls (`sys_clock_gettime`, `sys_gettimeofday`, `sys_nanosleep`, `sleep()`, and `sys_setitimer`) implemented.
 
 ## 2. File-System Metadata & Maintenance
 - `stat` family (`sys_stat`, `sys_fstat`, `sys_lstat`).

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -42,5 +42,10 @@ The table below lists all system calls currently exposed by `kora/syscalls.h`. T
 | 36 | `sys_select` | Wait for descriptor readiness |
 | 37 | `sys_sem_wait` | Wait on a semaphore |
 | 38 | `sys_sem_post` | Post to a semaphore |
+| 39 | `sys_clock_gettime` | Get time from a clock |
+| 40 | `sys_gettimeofday` | Legacy time retrieval |
+| 41 | `sys_nanosleep` | Sleep for nanoseconds |
+| 42 | `sys_sleep` | Sleep for seconds |
+| 43 | `sys_setitimer` | Set an interval timer |
 
 `kora/syscalls.h` also defines constants for open flags, seek modes, status codes and directory entry types.  Those are mirrored in the header and should be used when porting applications.

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -59,6 +59,11 @@
     int linux_sys_select(int nfds, fd_set *r, fd_set *w, fd_set *e, struct timeval *tmo);
     int linux_sys_sem_wait(sem_t *sem);
     int linux_sys_sem_post(sem_t *sem);
+    int linux_sys_clock_gettime(clockid_t id, struct timespec *tp);
+    int linux_sys_gettimeofday(struct timeval *tv, void *tz);
+    int linux_sys_nanosleep(const struct timespec *req, struct timespec *rem);
+    unsigned linux_sys_sleep(unsigned seconds);
+    int linux_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_exists(const char *path, uint8_t *type);
@@ -98,6 +103,11 @@
     int macos_sys_select(int nfds, fd_set *r, fd_set *w, fd_set *e, struct timeval *tmo);
     int macos_sys_sem_wait(sem_t *sem);
     int macos_sys_sem_post(sem_t *sem);
+    int macos_sys_clock_gettime(clockid_t id, struct timespec *tp);
+    int macos_sys_gettimeofday(struct timeval *tv, void *tz);
+    int macos_sys_nanosleep(const struct timespec *req, struct timespec *rem);
+    unsigned macos_sys_sleep(unsigned seconds);
+    int macos_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_exists(const char *path, uint8_t *type);
@@ -137,6 +147,11 @@
     int windows_sys_select(int nfds, fd_set *r, fd_set *w, fd_set *e, struct timeval *tmo);
     int windows_sys_sem_wait(sem_t *sem);
     int windows_sys_sem_post(sem_t *sem);
+    int windows_sys_clock_gettime(clockid_t id, struct timespec *tp);
+    int windows_sys_gettimeofday(struct timeval *tv, void *tz);
+    int windows_sys_nanosleep(const struct timespec *req, struct timespec *rem);
+    unsigned windows_sys_sleep(unsigned seconds);
+    int windows_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_exists(const char *path, uint8_t *type);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -14,6 +14,8 @@ extern "C" {
 #include <stdint.h>  /* For uint32_t, uint64_t */
 #include <sys/types.h> /* For pid_t */
 #include <semaphore.h> /* For sem_t */
+#include <time.h>      /* For timespec */
+#include <sys/time.h>  /* For timeval */
 
 /**
  * System call numbers
@@ -56,6 +58,11 @@ extern "C" {
 #define SYS_SELECT     36  /* Wait for descriptor readiness */
 #define SYS_SEM_WAIT   37  /* Wait on a semaphore */
 #define SYS_SEM_POST   38  /* Post to a semaphore */
+#define SYS_CLOCK_GETTIME 39 /* Get time from a clock */
+#define SYS_GETTIMEOFDAY 40 /* Legacy time retrieval */
+#define SYS_NANOSLEEP  41  /* Sleep for nanoseconds */
+#define SYS_SLEEP      42  /* Sleep for seconds */
+#define SYS_SETITIMER  43  /* Set interval timer */
 
 /**
  * File open flags
@@ -416,6 +423,21 @@ int sys_sem_wait(sem_t *sem);
 
 /** Post to a semaphore */
 int sys_sem_post(sem_t *sem);
+
+/** Get time from a specific clock */
+int sys_clock_gettime(clockid_t id, struct timespec *tp);
+
+/** Get the current time of day */
+int sys_gettimeofday(struct timeval *tv, void *tz);
+
+/** Sleep for a number of nanoseconds */
+int sys_nanosleep(const struct timespec *req, struct timespec *rem);
+
+/** Sleep for a whole number of seconds */
+unsigned sys_sleep(unsigned seconds);
+
+/** Set an interval timer */
+int sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -16,6 +16,8 @@
 #include <semaphore.h>
 #include <sched.h>
 #include <sys/resource.h>
+#include <time.h>
+#include <sys/time.h>
 extern char **environ;
 
 /**
@@ -598,5 +600,32 @@ int linux_sys_sem_wait(sem_t *sem)
 int linux_sys_sem_post(sem_t *sem)
 {
     return sem_post(sem);
+}
+
+int linux_sys_clock_gettime(clockid_t id, struct timespec *tp)
+{
+    return clock_gettime(id, tp);
+}
+
+int linux_sys_gettimeofday(struct timeval *tv, void *tz)
+{
+    (void)tz;
+    return gettimeofday(tv, NULL);
+}
+
+int linux_sys_nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    return nanosleep(req, rem);
+}
+
+unsigned linux_sys_sleep(unsigned seconds)
+{
+    struct timespec req = { (time_t)seconds, 0 };
+    return nanosleep(&req, NULL);
+}
+
+int linux_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old)
+{
+    return setitimer(which, new, old);
 }
 

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -17,6 +17,8 @@
 #include <semaphore.h>
 #include <sched.h>
 #include <sys/resource.h>
+#include <time.h>
+#include <sys/time.h>
 extern char **environ;
 
 /**
@@ -582,6 +584,33 @@ int macos_sys_sem_wait(sem_t *sem)
 int macos_sys_sem_post(sem_t *sem)
 {
     return sem_post(sem);
+}
+
+int macos_sys_clock_gettime(clockid_t id, struct timespec *tp)
+{
+    return clock_gettime(id, tp);
+}
+
+int macos_sys_gettimeofday(struct timeval *tv, void *tz)
+{
+    (void)tz;
+    return gettimeofday(tv, NULL);
+}
+
+int macos_sys_nanosleep(const struct timespec *req, struct timespec *rem)
+{
+    return nanosleep(req, rem);
+}
+
+unsigned macos_sys_sleep(unsigned seconds)
+{
+    struct timespec req = { (time_t)seconds, 0 };
+    return nanosleep(&req, NULL);
+}
+
+int macos_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old)
+{
+    return setitimer(which, new, old);
 }
 
 #endif // KORA_PLATFORM_MACOS

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -386,3 +386,53 @@ int sys_sem_post(sem_t *sem) {
     return windows_sys_sem_post(sem);
 #endif
 }
+
+int sys_clock_gettime(clockid_t id, struct timespec *tp) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_clock_gettime(id, tp);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_clock_gettime(id, tp);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_clock_gettime(id, tp);
+#endif
+}
+
+int sys_gettimeofday(struct timeval *tv, void *tz) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_gettimeofday(tv, tz);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_gettimeofday(tv, tz);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_gettimeofday(tv, tz);
+#endif
+}
+
+int sys_nanosleep(const struct timespec *req, struct timespec *rem) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_nanosleep(req, rem);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_nanosleep(req, rem);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_nanosleep(req, rem);
+#endif
+}
+
+unsigned sys_sleep(unsigned seconds) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_sleep(seconds);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_sleep(seconds);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_sleep(seconds);
+#endif
+}
+
+int sys_setitimer(int which, const struct itimerval *new, struct itimerval *old) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_setitimer(which, new, old);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_setitimer(which, new, old);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_setitimer(which, new, old);
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -2,6 +2,8 @@
 #include <sys/types.h>
 #include <semaphore.h>
 #include <sys/select.h>
+#include <time.h>
+#include <sys/time.h>
 
 /**
  * Windows implementation of KoraOS system calls
@@ -150,6 +152,31 @@ int windows_sys_sem_wait(sem_t *sem) {
 int windows_sys_sem_post(sem_t *sem) {
     (void)sem;
     /* TODO: Implement Windows version */
+    return -1;
+}
+
+int windows_sys_clock_gettime(clockid_t id, struct timespec *tp) {
+    (void)id; (void)tp;
+    return -1;
+}
+
+int windows_sys_gettimeofday(struct timeval *tv, void *tz) {
+    (void)tv; (void)tz;
+    return -1;
+}
+
+int windows_sys_nanosleep(const struct timespec *req, struct timespec *rem) {
+    (void)req; (void)rem;
+    return -1;
+}
+
+unsigned windows_sys_sleep(unsigned seconds) {
+    (void)seconds;
+    return seconds;
+}
+
+int windows_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old) {
+    (void)which; (void)new; (void)old;
     return -1;
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_FILES
     test_dup.c
     test_select.c
     test_sem.c
+    test_time.c
 )
 
 # Platform specific test configurations

--- a/tests/test_time.c
+++ b/tests/test_time.c
@@ -1,0 +1,48 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+
+static void test_clock_gettime_call(void **state) {
+    (void)state;
+    struct timespec ts;
+    assert_int_equal(sys_clock_gettime(CLOCK_REALTIME, &ts), 0);
+    assert_true(ts.tv_sec > 0);
+}
+
+static void test_gettimeofday_call(void **state) {
+    (void)state;
+    struct timeval tv;
+    assert_int_equal(sys_gettimeofday(&tv, NULL), 0);
+    assert_true(tv.tv_sec > 0);
+}
+
+static void test_nanosleep_call(void **state) {
+    (void)state;
+    struct timespec start, end, req = {0, 100000000};
+    assert_int_equal(sys_clock_gettime(CLOCK_MONOTONIC, &start), 0);
+    assert_int_equal(sys_nanosleep(&req, NULL), 0);
+    assert_int_equal(sys_clock_gettime(CLOCK_MONOTONIC, &end), 0);
+    assert_true((end.tv_sec > start.tv_sec) ||
+                (end.tv_sec == start.tv_sec && end.tv_nsec >= start.tv_nsec + 100000000));
+}
+
+static void test_sleep_wrapper(void **state) {
+    (void)state;
+    struct timespec start, end;
+    assert_int_equal(sys_clock_gettime(CLOCK_MONOTONIC, &start), 0);
+    assert_int_equal(sys_sleep(1), 0);
+    assert_int_equal(sys_clock_gettime(CLOCK_MONOTONIC, &end), 0);
+    assert_true(end.tv_sec >= start.tv_sec + 1);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_clock_gettime_call),
+        cmocka_unit_test(test_gettimeofday_call),
+        cmocka_unit_test(test_nanosleep_call),
+        cmocka_unit_test(test_sleep_wrapper),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- implement timer syscalls across platforms
- add wrappers in public API and update syscall table docs
- document completed timer tasks in PRD
- provide stubs for Windows
- add unit tests for timing functions

## Testing
- `./build.sh --test` *(fails: Could NOT find CMocka)*

------
https://chatgpt.com/codex/tasks/task_e_686fd745e710832ab7ea8691e1162402