### PR TITLE
Add signal system call support

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -9,7 +9,7 @@ This document outlines the remaining work required to flesh out the KoraOS C lib
 *(completed)*
 
 ## 3. Signals & Exceptions
-- Basic signal handling with `sys_signal`, `sys_kill`, and `sys_sigreturn`.
+*(completed)*
 
 ## 4. Device & Power Management (Stretch)
 - Stubs for `sys_sync`, `sys_reboot`, and `sys_mount`.

--- a/docs/syscalls.md
+++ b/docs/syscalls.md
@@ -54,5 +54,8 @@ The table below lists all system calls currently exposed by `kora/syscalls.h`. T
 | 48 | `sys_chdir` | Change current directory |
 | 49 | `sys_getcwd` | Get current working directory |
 | 50 | `sys_utime` | Update file timestamps |
+| 51 | `sys_signal` | Install a signal handler |
+| 52 | `sys_kill` | Send a signal to a process |
+| 53 | `sys_sigreturn` | Return from a signal handler |
 
 `kora/syscalls.h` also defines constants for open flags, seek modes, status codes and directory entry types.  Those are mirrored in the header and should be used when porting applications.

--- a/include/internal/syscall_impl.h
+++ b/include/internal/syscall_impl.h
@@ -64,6 +64,9 @@
     int linux_sys_nanosleep(const struct timespec *req, struct timespec *rem);
     unsigned linux_sys_sleep(unsigned seconds);
     int linux_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
+    sighandler_t linux_sys_signal(int signum, sighandler_t handler);
+    int linux_sys_kill(pid_t pid, int signum);
+    int linux_sys_sigreturn(void);
     int linux_sys_get_file_info(const char *path, kora_file_info_t *info);
     int linux_sys_get_fd_info(int fd, kora_file_info_t *info);
     int linux_sys_stat(const char *path, kora_stat_t *st);
@@ -115,6 +118,9 @@
     int macos_sys_nanosleep(const struct timespec *req, struct timespec *rem);
     unsigned macos_sys_sleep(unsigned seconds);
     int macos_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
+    sighandler_t macos_sys_signal(int signum, sighandler_t handler);
+    int macos_sys_kill(pid_t pid, int signum);
+    int macos_sys_sigreturn(void);
     int macos_sys_get_file_info(const char *path, kora_file_info_t *info);
     int macos_sys_get_fd_info(int fd, kora_file_info_t *info);
     int macos_sys_stat(const char *path, kora_stat_t *st);
@@ -166,6 +172,9 @@
     int windows_sys_nanosleep(const struct timespec *req, struct timespec *rem);
     unsigned windows_sys_sleep(unsigned seconds);
     int windows_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
+    sighandler_t windows_sys_signal(int signum, sighandler_t handler);
+    int windows_sys_kill(pid_t pid, int signum);
+    int windows_sys_sigreturn(void);
     int windows_sys_get_file_info(const char *path, kora_file_info_t *info);
     int windows_sys_get_fd_info(int fd, kora_file_info_t *info);
     int windows_sys_stat(const char *path, kora_stat_t *st);

--- a/include/kora/syscalls.h
+++ b/include/kora/syscalls.h
@@ -16,6 +16,7 @@ extern "C" {
 #include <semaphore.h> /* For sem_t */
 #include <time.h>      /* For timespec */
 #include <sys/time.h>  /* For timeval */
+#include <signal.h>    /* For sighandler_t */
 
 /**
  * System call numbers
@@ -70,6 +71,9 @@ extern "C" {
 #define SYS_CHDIR      48  /* Change current directory */
 #define SYS_GETCWD     49  /* Get current working directory */
 #define SYS_UTIME      50  /* Update file timestamps */
+#define SYS_SIGNAL     51  /* Install a signal handler */
+#define SYS_KILL       52  /* Send a signal to a task */
+#define SYS_SIGRETURN  53  /* Return from signal handler */
 
 /**
  * File open flags
@@ -483,6 +487,15 @@ unsigned sys_sleep(unsigned seconds);
 
 /** Set an interval timer */
 int sys_setitimer(int which, const struct itimerval *new, struct itimerval *old);
+
+/** Install a signal handler */
+sighandler_t sys_signal(int signum, sighandler_t handler);
+
+/** Send a signal to a process or group */
+int sys_kill(pid_t pid, int signum);
+
+/** Return from a signal handler */
+int sys_sigreturn(void);
 
 #ifdef __cplusplus
 }

--- a/src/linux/syscalls_linux.c
+++ b/src/linux/syscalls_linux.c
@@ -18,6 +18,7 @@
 #include <sys/resource.h>
 #include <time.h>
 #include <sys/time.h>
+#include <signal.h>
 extern char **environ;
 
 /**
@@ -735,5 +736,20 @@ unsigned linux_sys_sleep(unsigned seconds)
 int linux_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old)
 {
     return setitimer(which, new, old);
+}
+
+sighandler_t linux_sys_signal(int signum, sighandler_t handler)
+{
+    return signal(signum, handler);
+}
+
+int linux_sys_kill(pid_t pid, int signum)
+{
+    return kill(pid, signum);
+}
+
+int linux_sys_sigreturn(void)
+{
+    return 0;
 }
 

--- a/src/macos/syscalls_macos.c
+++ b/src/macos/syscalls_macos.c
@@ -18,6 +18,7 @@
 #include <sched.h>
 #include <sys/resource.h>
 #include <time.h>
+#include <signal.h>
 #include <sys/time.h>
 extern char **environ;
 
@@ -733,6 +734,21 @@ unsigned macos_sys_sleep(unsigned seconds)
 int macos_sys_setitimer(int which, const struct itimerval *new, struct itimerval *old)
 {
     return setitimer(which, new, old);
+}
+
+sighandler_t macos_sys_signal(int signum, sighandler_t handler)
+{
+    return signal(signum, handler);
+}
+
+int macos_sys_kill(pid_t pid, int signum)
+{
+    return kill(pid, signum);
+}
+
+int macos_sys_sigreturn(void)
+{
+    return 0;
 }
 
 #endif // KORA_PLATFORM_MACOS

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -506,3 +506,33 @@ int sys_setitimer(int which, const struct itimerval *new, struct itimerval *old)
     return windows_sys_setitimer(which, new, old);
 #endif
 }
+
+sighandler_t sys_signal(int signum, sighandler_t handler) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_signal(signum, handler);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_signal(signum, handler);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_signal(signum, handler);
+#endif
+}
+
+int sys_kill(pid_t pid, int signum) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_kill(pid, signum);
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_kill(pid, signum);
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_kill(pid, signum);
+#endif
+}
+
+int sys_sigreturn(void) {
+#if defined(KORA_PLATFORM_LINUX)
+    return linux_sys_sigreturn();
+#elif defined(KORA_PLATFORM_MACOS)
+    return macos_sys_sigreturn();
+#elif defined(KORA_PLATFORM_WINDOWS)
+    return windows_sys_sigreturn();
+#endif
+}

--- a/src/windows/syscalls_windows.c
+++ b/src/windows/syscalls_windows.c
@@ -224,4 +224,18 @@ int windows_sys_setitimer(int which, const struct itimerval *new, struct itimerv
     (void)which; (void)new; (void)old;
     return -1;
 }
+
+sighandler_t windows_sys_signal(int signum, sighandler_t handler) {
+    (void)signum; (void)handler;
+    return SIG_ERR;
+}
+
+int windows_sys_kill(pid_t pid, int signum) {
+    (void)pid; (void)signum;
+    return -1;
+}
+
+int windows_sys_sigreturn(void) {
+    return -1;
+}
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_FILES
     test_sem.c
     test_time.c
     test_stat.c
+    test_signal.c
 )
 
 # Platform specific test configurations

--- a/tests/test_signal.c
+++ b/tests/test_signal.c
@@ -1,0 +1,52 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <kora/syscalls.h>
+#include <signal.h>
+
+static volatile int handled = 0;
+
+static void sigusr1_handler(int signo) {
+    (void)signo;
+    handled = 1;
+    sys_sigreturn();
+}
+
+static void test_signal_send(void **state) {
+    (void)state;
+    handled = 0;
+    assert_ptr_not_equal(sys_signal(SIGUSR1, sigusr1_handler), SIG_ERR);
+    assert_int_equal(sys_kill(sys_getpid(), SIGUSR1), 0);
+    struct timespec ts = {0, 1000000};
+    sys_nanosleep(&ts, NULL);
+    assert_true(handled);
+}
+
+static volatile int alarmed = 0;
+
+static void alarm_handler(int signo) {
+    (void)signo;
+    alarmed = 1;
+    sys_sigreturn();
+}
+
+static void test_signal_interrupt_sleep(void **state) {
+    (void)state;
+    alarmed = 0;
+    assert_ptr_not_equal(sys_signal(SIGALRM, alarm_handler), SIG_ERR);
+    struct itimerval it = { {0,0}, {0,100000} };
+    assert_int_equal(sys_setitimer(ITIMER_REAL, &it, NULL), 0);
+    struct timespec req = {1, 0};
+    int ret = sys_nanosleep(&req, NULL);
+    assert_true(ret != 0);
+    assert_true(alarmed);
+}
+
+int main(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_signal_send),
+        cmocka_unit_test(test_signal_interrupt_sleep),
+    };
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- implement `sys_signal`, `sys_kill` and `sys_sigreturn`
- provide Linux and macOS implementations
- add Windows stubs
- document new system calls and mark signal tasks complete in PRD
- introduce unit tests for the new signal API
